### PR TITLE
static security code analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ package: version
 testenv:
 	test -z $(TRAVIS) && (test -d .ci-env || ( mkdir .ci-env && virtualenv .ci-env )) || true
 	test -z $(TRAVIS) && \
-		(echo "Non Travis" && .ci-env/bin/pip install -r requirements.txt -r requirements-dev.txt) || \
+		(echo "Non Travis" && .ci-env/bin/pip install -r requirements.txt -r requirements-dev.txt --upgrade) || \
 		(echo "Travis" && pip install -r requirements.txt -r requirements-dev.txt)
 
 test: version testenv

--- a/aomi/cli.py
+++ b/aomi/cli.py
@@ -249,8 +249,8 @@ def parser_factory(fake_args=None):
 
     if fake_args is None:
         return parser, parser.parse_args()
-    else:
-        return parser, parser.parse_args(fake_args)
+
+    return parser, parser.parse_args(fake_args)
 
 
 def parse_extra_vars(extra_vars):

--- a/aomi/exceptions.py
+++ b/aomi/exceptions.py
@@ -66,3 +66,9 @@ class VaultData(AomiError):
     """Something is wrong with data received from Vault. Usually
     indicates aomi trying to interact with something manually created"""
     catmsg = 'Unexpected Vault Data Woe'
+
+
+class Validation(AomiError):
+    """Some kind of validation failed. Invalid string, length,
+    who knows. Never trust user input tho."""
+    catmsg = 'Validation Error'

--- a/aomi/filez.py
+++ b/aomi/filez.py
@@ -13,6 +13,8 @@ from aomi.vault import get_secretfile
 from aomi.gpg import key_from_keybase, has_gpg_key, \
     import_gpg_key, encrypt, decrypt
 from aomi.validation import sanitize_mount
+from aomi.validation import gpg_fingerprint \
+    as validate_gpg_fingerprint
 import aomi.exceptions
 from aomi.util import validate_entry
 
@@ -45,6 +47,7 @@ def grok_keys(config, opt):
             log("Encrypting for gpg id %s" % key, opt)
             key_id = key
 
+        validate_gpg_fingerprint(key_id)
         key_ids.append(key_id)
 
     return key_ids

--- a/aomi/helpers.py
+++ b/aomi/helpers.py
@@ -16,9 +16,9 @@ def my_version():
     """Return the version, checking both packaged and development locations"""
     if os.path.exists(resource_filename(__name__, 'version')):
         return resource_string(__name__, 'version')
-    else:
-        return open(os.path.join(os.path.dirname(__file__),
-                                 "..", "version")).read()
+
+    return open(os.path.join(os.path.dirname(__file__),
+                             "..", "version")).read()
 
 VERSION = my_version()
 
@@ -58,17 +58,17 @@ def hard_path(path, prefix_dir):
 
 def is_tagged(has_tags, required_tags):
     """Checks if tags match"""
-    if len(required_tags) == 0 and len(has_tags) == 0:
+    if not required_tags and not has_tags:
         return True
-    elif len(required_tags) == 0:
+    elif not required_tags:
         return False
-    else:
-        found_tags = []
-        for tag in required_tags:
-            if tag in has_tags:
-                found_tags.append(tag)
 
-        return len(found_tags) == len(required_tags)
+    found_tags = []
+    for tag in required_tags:
+        if tag in has_tags:
+            found_tags.append(tag)
+
+    return len(found_tags) == len(required_tags)
 
 
 def cli_hash(list_of_kv):
@@ -127,8 +127,8 @@ def get_password(opt, confirm=True):
     """Will return a password in an appropriate fashion"""
     if sys.stdin.isatty():
         return get_tty_password(opt, confirm)
-    else:
-        return get_stdin_password(opt)
+
+    return get_stdin_password(opt)
 
 
 def path_pieces(vault_path):

--- a/aomi/helpers.py
+++ b/aomi/helpers.py
@@ -4,7 +4,7 @@ import collections
 import itertools as IT
 import sys
 import os
-import random
+from random import SystemRandom
 from getpass import getpass
 from pkg_resources import resource_string, resource_filename
 # Python 2/3 compat
@@ -176,7 +176,7 @@ def load_word_file(filename):
 
 def choose_one(things):
     """Returns a random entry from a list of things"""
-    choice = random.randint(0, len(things) - 1)
+    choice = SystemRandom().randint(0, len(things) - 1)
     return things[choice].strip()
 
 

--- a/aomi/legacy.py
+++ b/aomi/legacy.py
@@ -21,20 +21,20 @@ def aws_region(secret, aws_obj):
     """Return the AWS region with appropriate output"""
     if 'region' in secret:
         return secret['region']
-    else:
-        # see https://github.com/Autodesk/aomi/issues/40
-        warning('Defining region in the AWS yaml is deprecated')
-        return aws_obj['region']
+
+    # see https://github.com/Autodesk/aomi/issues/40
+    warning('Defining region in the AWS yaml is deprecated')
+    return aws_obj['region']
 
 
 def aws_roles(secret, aws_obj):
     """Return the AWS roles with appropriate output"""
     if 'roles' in secret:
         return secret['roles']
-    else:
-        # see https://github.com/Autodesk/aomi/issues/40
-        warning('Defining roles within the AWS yaml is deprecated')
-        return aws_obj['roles']
+
+    # see https://github.com/Autodesk/aomi/issues/40
+    warning('Defining roles within the AWS yaml is deprecated')
+    return aws_obj['roles']
 
 
 def app_id_policy_file(app_obj, data):

--- a/aomi/render.py
+++ b/aomi/render.py
@@ -19,8 +19,8 @@ def grok_seconds(lease):
         return int(lease[0:-1]) * 60
     elif lease.endswith('h'):
         return int(lease[0:-1]) * 3600
-    else:
-        return None
+
+    return None
 
 
 def is_aws(data):
@@ -64,10 +64,10 @@ def grok_template_file(src):
     """Determine the real deal template file"""
     if not src.startswith('builtin:'):
         return abspath(src)
-    else:
-        builtin = src.split(':')[1]
-        builtin = "templates/%s.j2" % builtin
-        return resource_filename(__name__, builtin)
+
+    builtin = src.split(':')[1]
+    builtin = "templates/%s.j2" % builtin
+    return resource_filename(__name__, builtin)
 
 
 def blend_vars(secrets, opt):
@@ -173,7 +173,7 @@ def aws(client, path, opt):
             error_output("Invalid AWS path. Did you forget the"
                          " credential type and role?", opt)
         else:
-            raise vault_exception
+            raise
 
     # this is how new vault behaves
     if not creds:

--- a/aomi/seed.py
+++ b/aomi/seed.py
@@ -53,7 +53,7 @@ def actually_mount(client, backend, mount):
                     (mount, match.group('path'))
             raise aomi.exceptions.VaultConstraint(e_msg)
         else:
-            raise exception
+            raise
 
 
 def is_auth_backend(client, backend):
@@ -79,7 +79,7 @@ def write(client, path, varz, opt):
         if vault_exception.errors[0] == 'permission denied':
             error_output("Permission denied writing to %s" % path, opt)
         else:
-            raise vault_exception
+            raise
 
 
 def delete(client, path, opt):
@@ -92,7 +92,7 @@ def delete(client, path, opt):
         if vault_exception.errors[0] == 'permission denied':
             error_output("Permission denied deleting %s" % path, opt)
         else:
-            raise vault_exception
+            raise
 
 
 def var_file(client, secret, opt):

--- a/aomi/template.py
+++ b/aomi/template.py
@@ -35,14 +35,14 @@ def render(filename, obj):
     template_src = env.loader.get_source(env, os.path.basename(template_path))
     parsed_content = env.parse(template_src)
     template_vars = meta.find_undeclared_variables(parsed_content)
-    if len(template_vars) > 0:
+    if template_vars:
         missing_vars = []
         default_vars = grok_default_vars(parsed_content)
         for var in template_vars:
             if var not in default_vars and var not in obj:
                 missing_vars.append(var)
 
-        if len(missing_vars) > 0:
+        if missing_vars:
             e_msg = "Missing required variables %s" % ','.join(missing_vars)
             raise aomi.exceptions.AomiData(e_msg)
 
@@ -55,16 +55,16 @@ def portable_b64encode(thing):
     """Wrap b64encode for Python 2 & 3"""
     if sys.version_info >= (3, 0):
         return b64encode(bytes(thing, 'utf-8')).decode('utf-8')
-    else:
-        return b64encode(thing)
+
+    return b64encode(thing)
 
 
 def portable_b64decode(thing):
     """Consistent b64decode in Python 2 & 3"""
     if sys.version_info >= (3, 0):
         return b64decode(thing).decode('utf-8')
-    else:
-        return b64decode(thing)
+
+    return b64decode(thing)
 
 
 def load_var_files(opt):

--- a/aomi/validation.py
+++ b/aomi/validation.py
@@ -1,6 +1,7 @@
 """Some validation helpers for aomi"""
 from __future__ import print_function
 import os
+import re
 import platform
 import stat
 from aomi.helpers import abspath, is_tagged, log, subdir_path
@@ -212,3 +213,9 @@ def duo_obj(obj):
     check_obj(['host', 'creds', 'backend'], 'duo object', obj)
     if obj['backend'] != 'userpass':
         raise aomi.exceptions.AomiData('Invalid duo backend selected')
+
+
+def gpg_fingerprint(key):
+    """Validates a GPG key fingerprint"""
+    if len(key) != 8 or not re.match(r'[0-9A-F]{8}', key):
+        raise aomi.exceptions.Validation('Invalid GPG Fingerprint')

--- a/aomi/validation.py
+++ b/aomi/validation.py
@@ -71,8 +71,8 @@ def validate_obj(keys, obj):
     msg = ''
     for k in keys:
         if isinstance(k, str):
-            if k not in obj or len(obj[k]) == 0:
-                if len(msg) > 0:
+            if k not in obj or not obj[k]:
+                if msg:
                     msg = "%s," % msg
 
                 msg = "%s%s" % (msg, k)
@@ -83,12 +83,12 @@ def validate_obj(keys, obj):
                     found = True
 
             if not found:
-                if len(msg) > 0:
+                if msg:
                     msg = "%s," % msg
 
                 msg = "%s(%s" % (msg, ','.join(k))
 
-    if len(msg) > 0:
+    if msg:
         msg = "%s missing" % msg
 
     return msg
@@ -129,18 +129,18 @@ def tag_check(obj, path, opt):
         log("Skipping %s as it does not have requested tags" %
             path, opt)
         return False
-    else:
-        return True
+
+    return True
 
 
 def specific_path_check(path, opt):
     """Will make checks against include/exclude to determine if we
     actually care about the path in question."""
-    if len(opt.exclude) > 0:
+    if opt.exclude:
         if path in opt.exclude:
             return False
 
-    if len(opt.include) > 0:
+    if opt.include:
         if path not in opt.include:
             return False
 
@@ -150,7 +150,7 @@ def specific_path_check(path, opt):
 def check_obj(keys, name, obj):
     """Do basic validation on an object"""
     msg = validate_obj(keys, obj)
-    if len(msg) > 0:
+    if msg:
         raise aomi.exceptions.AomiData("object check : %s in %s" % (msg, name))
 
 

--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -45,13 +45,12 @@ def initial_token(vault_client, opt):
                               os.path.join(home, ".aomi-app-token"))
     token_file = abspath(token_file)
     app_file = abspath(app_file)
-    if 'VAULT_TOKEN' in os.environ and len(os.environ['VAULT_TOKEN']) > 0:
+    if 'VAULT_TOKEN' in os.environ and os.environ['VAULT_TOKEN']:
         log('Token derived from VAULT_TOKEN environment variable', opt)
         return os.environ['VAULT_TOKEN'].strip()
     elif 'VAULT_USER_ID' in os.environ and \
          'VAULT_APP_ID' in os.environ and \
-         len(os.environ['VAULT_USER_ID']) > 0 and \
-         len(os.environ['VAULT_APP_ID']) > 0:
+         os.environ['VAULT_USER_ID'] and os.environ['VAULT_APP_ID']:
         token = app_token(vault_client,
                           os.environ['VAULT_APP_ID'].strip(),
                           os.environ['VAULT_USER_ID'].strip())
@@ -59,8 +58,7 @@ def initial_token(vault_client, opt):
         return token
     elif 'VAULT_ROLE_ID' in os.environ and \
          'VAULT_SECRET_ID' in os.environ and \
-         len(os.environ['VAULT_ROLE_ID']) > 0 and \
-         len(os.environ['VAULT_SECRET_ID']) > 0:
+         os.environ['VAULT_ROLE_ID'] and os.environ['VAULT_SECRET_ID']:
         token = approle_token(vault_client,
                               os.environ['VAULT_ROLE_ID'],
                               os.environ['VAULT_SECRET_ID'])
@@ -120,7 +118,7 @@ def operational_token(vault_client, operation, opt):
         if vault_exception.errors[0] == 'permission denied':
             error_output("Permission denied creating operational token", opt)
         else:
-            raise vault_exception
+            raise
 
     log("Using lease of %s" % opt.lease, opt)
     return token['auth']['client_token']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ ipdb
 awscli
 pylint
 future
-
+bandit

--- a/scripts/ci
+++ b/scripts/ci
@@ -8,3 +8,4 @@ fi
 "${PREFIX}pep8" aomi
 "${PREFIX}pylint" --rcfile=/dev/null aomi
 "${PREFIX}nose2"
+"${PREFIX}bandit" -r aomi


### PR DESCRIPTION
The test suite now invokes [bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit) to check for some common python security issues. The few `#nosec` annotations I added were to some use of `subprocess`. As part of this, I confirmed all the input being fed into a shell.

Also made it so that the non-travis test suite will always ensure we have the most recent dependencies.