### PR TITLE
always create aws credentials, since we cannot actualy verify

### DIFF
--- a/aomi/model/aws.py
+++ b/aomi/model/aws.py
@@ -84,7 +84,7 @@ class AWS(Secret):
         if is_mounted(self.backend,
                       self.mount,
                       vault_client.list_secret_backends()):
-            self.existing = True
+            self.existing = False
 
     def sync(self, vault_client):
         if self.present and not self.existing:


### PR DESCRIPTION
The thing that makes me 😿 is that our tests should handle this... Need to investigate that.

cc @Vidhixa