### PR TITLE
add approle auth

### DIFF
--- a/aomi/cli.py
+++ b/aomi/cli.py
@@ -12,7 +12,7 @@ import aomi.util
 import aomi.filez
 import aomi.seed_action
 from aomi.helpers import VERSION as version
-from aomi.util import token_file, appid_file
+from aomi.util import token_file, appid_file, approle_file
 from aomi.error import unhandled
 LOG = logging.getLogger(__name__)
 
@@ -25,14 +25,16 @@ def help_me(parser, opt):
     if opt.verbose == 2:
         tf_str = 'Token File,' if token_file() else ''
         app_str = 'AppID File,' if appid_file() else ''
+        approle_str = 'Approle File,' if approle_file() else ''
         tfe_str = 'Token Env,' if 'VAULT_TOKEN' in os.environ else ''
         appre_str = 'App Role Env,' if 'VAULT_ROLE_ID' in os.environ and \
                     'VAULT_SECRET_ID' in os.environ else ''
         appe_str = 'AppID Env,' if 'VAULT_USER_ID' in os.environ and \
                    'VAULT_APP_ID' in os.environ else ''
 
-        LOG.info(("Auth Hints Present : %s%s%s%s%s" %
-                  (tf_str, app_str, tfe_str, appre_str, appe_str))[:-1])
+        LOG.info(("Auth Hints Present : %s%s%s%s%s%s" %
+                  (tf_str, app_str, approle_str, tfe_str,
+                   appre_str, appe_str))[:-1])
         LOG.info("Vault Server %s" %
                  os.environ['VAULT_ADDR']
                  if 'VAULT_ADDR' in os.environ else '??')
@@ -414,7 +416,7 @@ def action_runner(parser, args):
     elif args.operation == 'template':
         template_runner(client.connect(args), parser, args)
     elif args.operation == 'token':
-        print(client.token)
+        print(client.connect(args).token)
         sys.exit(0)
     elif args.operation == 'set_password':
         aomi.util.password(client.connect(args), args.vault_path)

--- a/aomi/model/auth.py
+++ b/aomi/model/auth.py
@@ -13,7 +13,7 @@ import aomi.exceptions
 from aomi.vault import wrap_hvac as wrap_vault
 from aomi.helpers import hard_path, merge_dicts, cli_hash
 from aomi.template import load_var_files, render
-from aomi.model.resource import Auth, Resource
+from aomi.model.resource import Auth, Resource, NOOP, ADD
 from aomi.validation import secret_file, sanitize_mount
 LOG = logging.getLogger(__name__)
 
@@ -107,7 +107,10 @@ class AppRoleSecret(Resource):
         super(AppRoleSecret, self).__init__(obj, opt)
 
     def diff(self, obj=None):
-        return Resource.diff_write_only(self)
+        if 'secret_id_accessor' in self.existing:
+            return NOOP
+
+        return ADD
 
     def obj(self):
         filename = hard_path(self.filename, self.opt.secrets)

--- a/aomi/util.py
+++ b/aomi/util.py
@@ -99,3 +99,8 @@ def token_file():
 def appid_file():
     """The path to an Aomi AppID file"""
     return vault_file('AOMI_APP_FILE', '.aomi-app-token')
+
+
+def approle_file():
+    """The path to an Aomi AppID file"""
+    return vault_file('AOMI_APPROLE_FILE', '.aomi-approle')


### PR DESCRIPTION
Can now get a token via approle role_id/secret_id in a yaml file. Changed the ordering of how the various hints are interpreted as well.