### PR TITLE
Fix key in an AppRole definition example

### DIFF
--- a/docs/auth-resources.md
+++ b/docs/auth-resources.md
@@ -22,7 +22,7 @@ approles:
   policies:
   - 'default'
   - 'not_default'
-  secret_users: 1
+  secret_uses: 1
   secret_ttl: 1
 ```
 


### PR DESCRIPTION
`AppRole.__init__` [expects](https://github.com/Autodesk/aomi/blob/4f549dd2150a419e3012286ed996cf70077b1ea9/aomi/model/auth.py#L188) "secret_uses" key.

I fix docs and not `AppRole.__init__`, because Vault option is called [`secret_id_num_uses`](https://www.vaultproject.io/docs/auth/approle.html#auth-approle-role-role_name-), so aomi should use `_uses` too.