### PR TITLE
Reorder AppRole.map_val parameters

### DIFF
--- a/aomi/model/auth.py
+++ b/aomi/model/auth.py
@@ -161,7 +161,7 @@ class AppRole(Auth):
     config_key = 'approles'
 
     @staticmethod
-    def map_val(src, dest, key, default, src_key=None):
+    def map_val(dest, src, key, default, src_key=None):
         """Will ensure a dict has values sourced from either
         another dict or based on the provided default"""
         if not src_key:


### PR DESCRIPTION
`AppRole.map_val` is only used by `AppRole.__init__`, and the latter passes [`dest` dict as the first argument](https://github.com/Autodesk/aomi/blob/028d75307a54f69b27a53a0a349910af7e3aac47/aomi/model/auth.py#L184-L194), while `map_val` has [`src` as the first parameter](https://github.com/Autodesk/aomi/blob/028d75307a54f69b27a53a0a349910af7e3aac47/aomi/model/auth.py#L163-L173).

It makes sense to fix `map_val` signature and put `dest` on the first place. This way we change only one line and at the same time make it to follow [traditions of some other languages](http://lemire.me/blog/2016/09/06/function-signature-how-do-you-order-parameters/).

---

I noticed it fixing https://github.com/Autodesk/aomi/pull/126, but haven't checked if it's really a bug yet.

TBU.