### PR TITLE
Raise exception if VAULT_ADDR is empty

### DIFF
--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -99,8 +99,9 @@ class Client(hvac.Client):
     def __init__(self, _url=None, token=None, _cert=None, _verify=True,
                  _timeout=30, _proxies=None, _allow_redirects=True,
                  _session=None):
-        if 'VAULT_ADDR' not in os.environ:
-            raise aomi.exceptions.AomiError('VAULT_ADDR must be defined')
+        vault_addr = os.environ.get('VAULT_ADDR')
+        if not vault_addr:
+            raise aomi.exceptions.AomiError('VAULT_ADDR is undefined or empty')
 
         ssl_verify = True
         if 'VAULT_SKIP_VERIFY' in os.environ:
@@ -109,7 +110,7 @@ class Client(hvac.Client):
 
         self.initial_token = None
         self.operational_token = None
-        super(Client, self).__init__(url=os.environ['VAULT_ADDR'],
+        super(Client, self).__init__(url=vault_addr,
                                      verify=ssl_verify)
 
     def connect(self, opt):


### PR DESCRIPTION
I forgot to set `VAULT_ADDR` value and got an unexpected error:

```
$ echo $VAULT_ADDR

$ docker run -e VAULT_ADDR=$VAULT_ADDR -v $(pwd)/.vault-token:/.vault-token autodesk/aomi diff
Unexpected error: requests.exceptions.MissingSchema
```

With `--verbose`:
```
$ docker run -e VAULT_ADDR=$VAULT_ADDR -v $(pwd)/.vault-token:/.vault-token autodesk/aomi diff --verbose
Connecting to
Token derived from /.vault-token
Unexpected error: requests.exceptions.MissingSchema
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/cli.py", line 439, in main
    action_runner(parser, args)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/cli.py", line 414, in action_runner
    aomi.seed_action.diff(client.connect(args), args)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/vault.py", line 123, in connect
    if not self.is_authenticated():
  File "build/bdist.linux-x86_64/egg/hvac/v1/__init__.py", line 514, in is_authenticated
    self.lookup_token()
  File "build/bdist.linux-x86_64/egg/hvac/v1/__init__.py", line 423, in lookup_token
    return self._get('/v1/auth/token/lookup-self', wrap_ttl=wrap_ttl).json()
  File "build/bdist.linux-x86_64/egg/hvac/v1/__init__.py", line 944, in _get
    return self.__request('get', url, **kwargs)
  File "build/bdist.linux-x86_64/egg/hvac/v1/__init__.py", line 972, in __request
    allow_redirects=False, **_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests-2.18.2-py2.7.egg/requests/sessions.py", line 488, in request
    prep = self.prepare_request(req)
  File "/usr/local/lib/python2.7/site-packages/requests-2.18.2-py2.7.egg/requests/sessions.py", line 431, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/local/lib/python2.7/site-packages/requests-2.18.2-py2.7.egg/requests/models.py", line 305, in prepare
    self.prepare_url(url, params)
  File "/usr/local/lib/python2.7/site-packages/requests-2.18.2-py2.7.egg/requests/models.py", line 379, in prepare_url
    raise MissingSchema(error)
MissingSchema: Invalid URL '/v1/auth/token/lookup-self': No schema supplied. Perhaps you meant http:///v1/auth/token/lookup-self?
```