### PR TITLE
Fix docs: mounts are defined using "path" key

### DIFF
--- a/docs/secretfile.md
+++ b/docs/secretfile.md
@@ -26,7 +26,7 @@ users:
   policies:
   - 'developer'
 mounts:
-- 'secret'
+- path: 'secret'
 secrets:
 - files:
   - source: 'id_rsa'
@@ -113,8 +113,8 @@ You can specify generic secret store mountpoints to be created but not neccesari
 
 ```
 mounts:
-- 'secret'
-- 'another_teams_secrets'
+- path: 'secret'
+- path: 'another_teams_secrets'
 ```
 
 # Secrets


### PR DESCRIPTION
[`Mount.__init__`](https://github.com/Autodesk/aomi/blob/4f1f163cd2dff7361dd43de48cf584794bce9cd9/aomi/model/resource.py#L280) and [tests](https://github.com/Autodesk/aomi/blob/b2d4272e98acfdb58b90b8add8e1ca612c7b726a/tests/integration/fixtures/seed/Secretfile#L2-L3) make it clear.

Without `path:` I get this:

```
$ docker run -e VAULT_ADDR=$VAULT_ADDR -v $(pwd)/aomi:/aomi -v $(pwd)/.vault-token:/.vault-token autodesk/aomi diff --secretfile /aomi/Secretfile --secrets /aomi/.secrets
Unexpected error: exceptions.AttributeError
```

With `--verbose`:
```
$ docker run -e VAULT_ADDR=$VAULT_ADDR -v $(pwd)/aomi:/aomi -v $(pwd)/.vault-token:/.vault-token autodesk/aomi diff --secretfile /aomi/Secretfile --secrets /aomi/.secrets --verbose
Connecting to http://10.0.0.1:8200
Token derived from /.vault-token
Unexpected error: exceptions.AttributeError
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/cli.py", line 439, in main
    action_runner(parser, args)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/cli.py", line 414, in action_runner
    aomi.seed_action.diff(client.connect(args), args)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/seed_action.py", line 117, in diff
    ctx = Context.load(get_secretfile(opt), opt) \
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/model/context.py", line 124, in load
    ctx.add(mod(resource, opt))
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/model/resource.py", line 279, in __init__
    super(Mount, self).__init__(obj, opt)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/model/resource.py", line 130, in __init__
    self.grok_state(obj)
  File "/usr/local/lib/python2.7/site-packages/aomi-1.6.0-py2.7.egg/aomi/model/resource.py", line 100, in grok_state
    self.present = obj.get('state', 'present').lower() == 'present'
AttributeError: 'str' object has no attribute 'get'
```