### PR TITLE
Support AppRole token_num_uses parameter

### DIFF
--- a/aomi/model/auth.py
+++ b/aomi/model/auth.py
@@ -190,6 +190,7 @@ class AppRole(Auth):
         AppRole.map_val(role_obj, obj, 'period', 0)
         AppRole.map_val(role_obj, obj, 'token_max_ttl', 0)
         AppRole.map_val(role_obj, obj, 'token_ttl', 0)
+        AppRole.map_val(role_obj, obj, 'token_num_uses', 0)
         AppRole.map_val(role_obj, obj, 'bind_secret_id', 'require_secret')
         self._obj = role_obj
         if 'preset' in obj:


### PR DESCRIPTION
[token_num_uses](https://www.vaultproject.io/docs/auth/approle.html#auth-approle-role-role_name-): optional Number of times issued tokens can be used.