### PR TITLE
Fix default value for bind_secret_id AppRole parameter

### DIFF
--- a/aomi/model/auth.py
+++ b/aomi/model/auth.py
@@ -190,7 +190,7 @@ class AppRole(Auth):
         AppRole.map_val(role_obj, obj, 'period', 0)
         AppRole.map_val(role_obj, obj, 'token_max_ttl', 0)
         AppRole.map_val(role_obj, obj, 'token_ttl', 0)
-        AppRole.map_val(role_obj, obj, 'bind_secret_id', 'require_secret')
+        AppRole.map_val(role_obj, obj, 'bind_secret_id', 'true')
         self._obj = role_obj
         if 'preset' in obj:
             self.presets(obj['preset'], opt)


### PR DESCRIPTION
Looks like `require_secret` was supposed to be passed to `map_val`'s `src_key` parameter, but in fact it's passed as `default` parameter, and it leads to this error:

```
InvalidRequest: Error converting input require_secret for field bind_secret_id:
cannot parse '' as bool: strconv.ParseBool: parsing "require_secret": invalid syntax
```

Following https://github.com/Autodesk/aomi/issues/129 I omit `src_key` parameter, so `bind_secret_id` parameter name should be used in Secretfiles.

Vault defaults `bind_secret_id` to `true`, so we replicate it here.

This commit "depends" on https://github.com/Autodesk/aomi/pull/127.
Without that PR merged the error is not raised, as all `map_val`'ed parameters are simply ignored.