### PR TITLE
backend ttls!

### DIFF
--- a/aomi/cli.py
+++ b/aomi/cli.py
@@ -416,6 +416,7 @@ def action_runner(parser, args):
 
     ux_actions(parser, args)
     client = aomi.vault.Client(args)
+
     if args.operation == 'extract_file':
         aomi.render.raw_file(client.connect(args),
                              args.vault_path, args.destination, args)

--- a/aomi/exceptions.py
+++ b/aomi/exceptions.py
@@ -72,3 +72,10 @@ class Validation(AomiError):
     """Some kind of validation failed. Invalid string, length,
     who knows. Never trust user input tho."""
     catmsg = 'Validation Error'
+
+
+class VaultProblem(AomiError):
+    """Something is wrong with Vault itself. Network, sealed,
+    but it's at the point where we can't even validate if
+    the data is there"""
+    catmsg = 'Vault Problem'

--- a/aomi/helpers.py
+++ b/aomi/helpers.py
@@ -282,4 +282,5 @@ def map_val(dest, src, key, default=None, src_key=None):
     if src_key in src:
         dest[key] = src[src_key]
     else:
-        dest[key] = default
+        if default is not None:
+            dest[key] = default

--- a/aomi/helpers.py
+++ b/aomi/helpers.py
@@ -249,11 +249,12 @@ def dict_unicodeize(some_dict):
     return some_dict
 
 
-def diff_dict(dict1, dict2):
+def diff_dict(dict1, dict2, ignore_missing=False):
     """Performs a base type comparison between two dicts"""
     unidict1 = dict_unicodeize(dict1)
     unidict2 = dict_unicodeize(dict2)
-    if len(unidict1) != len(unidict2):
+    if ((not ignore_missing) and (len(unidict1) != len(unidict2))) or \
+       (ignore_missing and (len(unidict1) >= len(unidict2))):
         return True
 
     for comp_k, comp_v in iteritems(unidict1):

--- a/aomi/model/__init__.py
+++ b/aomi/model/__init__.py
@@ -1,10 +1,10 @@
 """A Model definition of Vault resources"""
 
 #  Ensure every defined model is loaded I guess
-import aomi.model.generic
+import aomi.model.backend
+import aomi.model.resource
 import aomi.model.auth
 import aomi.model.aws
-import aomi.model.resource
-import aomi.model.backend
+import aomi.model.generic
 
 from aomi.model.context import Context

--- a/aomi/model/auth.py
+++ b/aomi/model/auth.py
@@ -385,9 +385,9 @@ class UserPass(Auth):
 
     def __init__(self, obj, opt):
         super(UserPass, self).__init__('userpass', obj, opt)
+        self.tunable(obj)
         self.mount = obj.get('path', 'userpass')
         self.path = "auth/%s" % self.mount
-        self.tunable(obj)
 
 
 class UserPassUser(Auth):

--- a/aomi/model/backend.py
+++ b/aomi/model/backend.py
@@ -40,12 +40,14 @@ class VaultBackend(object):
         self.existing_tune = None
         self.present = resource.present
         self.tune = dict()
-        if hasattr(resource, 'tune') and isinstance('tune', dict):
+        if hasattr(resource, 'tune') and isinstance(resource.tune, dict):
             for tunable in MOUNT_TUNABLES:
                 tunable_key = tunable[0]
                 tunable_type = tunable[1]
-                if not isinstance(resource.tune[tunable_key], tunable_type):
-                    e_msg = "Tunable must be of type %s" % tunable_type
+                if tunable_key in resource.tune and \
+                   not isinstance(resource.tune[tunable_key], tunable_type):
+                    e_msg = "Mount tunable %s on %s must be of type %s" % \
+                            (tunable_key, self.path, tunable_type)
                     raise aomi_excep.AomiData(e_msg)
 
                 map_val(self.tune, resource.tune, tunable_key)
@@ -67,7 +69,7 @@ class VaultBackend(object):
 
         is_diff = NOOP
         if self.present and self.existing:
-            if diff_dict(self.existing_tune, self.tune):
+            if self.tune and diff_dict(self.tune, self.existing_tune, True):
                 is_diff = CHANGED
 
         elif self.present and not self.existing:

--- a/aomi/model/resource.py
+++ b/aomi/model/resource.py
@@ -32,7 +32,8 @@ class Resource(object):
             src_file = "%s/%s" % (tmp_dir, sfile)
             err_msg = "%s secret missing from icefile" % (self)
             if not os.path.exists(src_file):
-                if self.opt.ignore_missing:
+                if hasattr(self.opt, 'ignore_missing') and \
+                   self.opt.ignore_missing:
                     LOG.warning(err_msg)
                     continue
                 else:

--- a/aomi/templates/aws-credentials.j2
+++ b/aomi/templates/aws-credentials.j2
@@ -13,7 +13,7 @@ aws_access_key_id = {{secret}}
 {% if key == "secret" -%}
 aws_secret_access_key = {{secret}}
 {% endif -%}
-{% if key == "security_token" -%}
+{% if key == "security" -%}
 aws_session_token = {{secret}}
 {% endif -%}
 {% endfor -%}

--- a/aomi/util.py
+++ b/aomi/util.py
@@ -104,3 +104,24 @@ def appid_file():
 def approle_file():
     """The path to an Aomi AppID file"""
     return vault_file('AOMI_APPROLE_FILE', '.aomi-approle')
+
+
+def vault_time_to_s(time_string):
+    """Will convert a time string, as recognized by other Vault
+    tooling, into an integer representation of seconds"""
+    if not time_string or len(time_string) < 2:
+        raise aomi.exceptions \
+                  .AomiData("Invalid timestring %s" % time_string)
+
+    last_char = time_string[len(time_string) - 1]
+    if last_char == 's':
+        return int(time_string[0:len(time_string) - 1])
+    elif last_char == 'h':
+        cur = int(time_string[0:len(time_string) - 1])
+        return cur * 3600
+    elif last_char == 'd':
+        cur = int(time_string[0:len(time_string) - 1])
+        return cur * 86400
+    else:
+        raise aomi.exceptions \
+            .AomiData("Invalid time scale %s" % last_char)

--- a/aomi/validation.py
+++ b/aomi/validation.py
@@ -128,6 +128,7 @@ def sanitize_mount(mount):
     if sanitized_mount.endswith('/'):
         sanitized_mount = sanitized_mount[:-1]
 
+    sanitized_mount = sanitized_mount.replace('//', '/')
     return sanitized_mount
 
 

--- a/aomi/validation.py
+++ b/aomi/validation.py
@@ -165,3 +165,9 @@ def is_unicode(string):
         return True
 
     return False
+
+
+def is_vault_time(time_string):
+    """Vaildates that an object is the sort of string that HCVault
+    would be totally OK with for things like TTL's"""
+    return re.match(r'^[0-9]+[sdmh]$', time_string)

--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -134,7 +134,7 @@ class Client(hvac.Client):
         Vault deployments."""
         health_url = "%s/v1/sys/health" % self.vault_addr
         resp = session.request('get', health_url)
-        if resp.status_code == 200:
+        if resp.status_code == 200 or resp.status_code == 429:
             blob = resp.json()
             if 'version' in blob:
                 return blob['version']

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This folder contains source for the aomi [webpage](https://autodesk.github.io/aomi/). While there are markdown pages within this folder, they are not meant to be browsable from the GitHub folder view.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,8 +1,11 @@
-title: aomi
-description: Opinionlessly Express Opinions on Vault
+---
+title: "aomi"
+description: "Opinionlessly Express Opinions on Vault"
 google_analytics:
 theme: 
 github:
-  repository_url: https://github.com/Autodesk/aomi
-  owner_name: Autodesk
-baseurl: /aomi
+  repository_url: "https://github.com/Autodesk/aomi"
+  owner_name: "Autodesk"
+baseurl: "/aomi"
+exclude:
+  - "README.md"

--- a/docs/secretfile.md
+++ b/docs/secretfile.md
@@ -27,6 +27,8 @@ users:
   - 'developer'
 mounts:
 - path: 'secret'
+  tune:
+    default_lease_ttl: '1800s'
 secrets:
 - files:
   - source: 'id_rsa'
@@ -104,7 +106,7 @@ $ aomi seed --extra-vars env=stage
 ```
 
 
-# Mountpoints
+# Generic Mountpoints
 
 You can specify generic secret store mountpoints to be created but not neccesarily provisioned with data. This is helpful when you have one group managing the base Vault instance but another group managing the data within certain mountpoints. The following example will ensure that the default generic backend (`secret)` is always present, along with a new mountpoint named `another_teams_secrets`.
 
@@ -116,6 +118,12 @@ mounts:
 - path: 'secret'
 - path: 'another_teams_secrets'
 ```
+
+Note that with older versions of Vault this was an optional section. If you specified any kind of Generic secret (such as a file or varfile), and the mountpoint didn't exist, then it would be created. This behaviour will eventually be deprecated, but for now just throws a warning. To reiterate; if you are writing to generic mountpoints other than `secret` (which is included as a default) then you _must_ specify them in the `mounts` section.
+
+# Mount Tuning
+
+On resources which are used to create new Vault backends you can specify a `tune` section which allows you to specify the two currently exposed tuning variables. These are `max_lease_ttl` and `default_lease_ttl`. You can set a `tune` section with `mounts`, `aws_file`, `userpass`, `ldap`, and `auditlog`. Note that _adjusting_ existing mountpoints is only supported with Vault versions 0.7.0 and later.
 
 # Secrets
 

--- a/tests/integration/auth.bats
+++ b/tests/integration/auth.bats
@@ -152,12 +152,12 @@ ldap_auth() {
 
 @test "userpass diff" {
     aomi_run diff --monochrome
-    scan_lines "\+ UserPass auth/userpass/users/foo" "${lines[@]}"    
+    scan_lines "\+ UserPass User Account auth/userpass/users/foo" "${lines[@]}"    
     aomi_seed
     aomi_run diff --monochrome
-    scan_lines "\+ UserPass auth/userpass/users/foo" "${lines[@]}"
+    scan_lines "\+ UserPass User Account auth/userpass/users/foo" "${lines[@]}"
     aomi_run diff --monochrome --tags remove    
-    scan_lines "\- UserPass auth/userpass/users/foo" "${lines[@]}"    
+    scan_lines "\- UserPass User Account auth/userpass/users/foo" "${lines[@]}"    
 }
 
 @test "duo userpass" {

--- a/tests/integration/diff.bats
+++ b/tests/integration/diff.bats
@@ -16,11 +16,11 @@ teardown() {
 @test "crud some diffs" {
     aomi_run diff --verbose --monochrome
     scan_lines "\+ Generic File secret/foo" "${lines[@]}"
-    scan_lines "\+ Vault Generic Backend also_secret" "${lines[@]}"
+    scan_lines "\+ generic also_secret" "${lines[@]}"
     aomi_seed
     aomi_run diff --verbose --monochrome --tags remove
     scan_lines "\- Generic File secret/foo" "${lines[@]}"
-    scan_lines "\- Vault Generic Backend also_secret" "${lines[@]}"
+    scan_lines "\- generic also_secret" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags mod
     scan_lines "\~ Generic File secret/foo" "${lines[@]}"
 }

--- a/tests/integration/diff.bats
+++ b/tests/integration/diff.bats
@@ -13,14 +13,34 @@ teardown() {
     rm -rf "$FIXTURE_DIR"
 }
 
-@test "crud some diffs" {
+@test "crud some policy diffs" {
+    aomi_run diff --verbose --monochrome
+    scan_lines "\+ Vault Policy foo" "${lines[@]}"
+    aomi_seed
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "\- Vault Policy foo" "${lines[@]}"
+    aomi_run diff --verbose --monochrome --tags mod
+    scan_lines "\~ Vault Policy foo" "${lines[@]}"
+    scan_lines "\-\- #test1" "${lines[@]}"
+    scan_lines "\+\+ #test2" "${lines[@]}"    
+}
+
+@test "crud some secret diffs" {
     aomi_run diff --verbose --monochrome
     scan_lines "\+ Generic File secret/foo" "${lines[@]}"
+    scan_lines "\+ Generic VarFile secret/bar" "${lines[@]}"
     scan_lines "\+ generic also_secret" "${lines[@]}"
     aomi_seed
     aomi_run diff --verbose --monochrome --tags remove
     scan_lines "\- Generic File secret/foo" "${lines[@]}"
+    scan_lines "\- Generic VarFile secret/bar" "${lines[@]}"    
     scan_lines "\- generic also_secret" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags mod
     scan_lines "\~ Generic File secret/foo" "${lines[@]}"
+    scan_lines "\-\- txt2: ${FILE_SECRET2}" "${lines[@]}"
+    scan_lines "\+\+ txt2: ${FILE_SECRET1}" "${lines[@]}"
+    scan_lines "\-\- secret: ${YAML_SECRET1}" "${lines[@]}"
+    scan_lines "\-\- secret2: ${YAML_SECRET1_2}" "${lines[@]}"
+    scan_lines "\+\+ secret: ${YAML_SECRET2}" "${lines[@]}"
+    scan_lines "\+\+ secret2: ${YAML_SECRET2_2}" "${lines[@]}"
 }

--- a/tests/integration/fixtures/auth/Secretfile
+++ b/tests/integration/fixtures/auth/Secretfile
@@ -15,8 +15,9 @@ approles:
       - name: "test"
         filename: "foo-test"
 userpass:
-  tune:
-    default_lease_ttl: "300s"
+  - description: "some kinda gate"
+    tune:
+      default_lease_ttl: "300s"
 users:
 - username: 'foo'
   password_file: 'secret.txt'

--- a/tests/integration/fixtures/auth/Secretfile
+++ b/tests/integration/fixtures/auth/Secretfile
@@ -14,11 +14,16 @@ approles:
     preset:
       - name: "test"
         filename: "foo-test"
+userpass:
+  tune:
+    default_lease_ttl: "300s"
 users:
 - username: 'foo'
   password_file: 'secret.txt'
   policies:
   - 'foo'
+  ttl: "1800s"
+  max_ttl: "86400s"
 - username: 'foo'
   password_file: 'secret2.txt'
   policies:

--- a/tests/integration/fixtures/diff/Secretfile
+++ b/tests/integration/fixtures/diff/Secretfile
@@ -34,3 +34,28 @@ secrets:
     path: "foo"
     tags:
       - "mod"
+  - var_file: "secret.yml"
+    mount: "secret"
+    path: "bar"
+  - var_file: "secret.yml"
+    mount: "secret"
+    path: "bar"
+    state: "absent"
+    tags:
+      - "remove"
+  - var_file: "secret2.yml"
+    mount: "secret"
+    path: "bar"
+    tags:
+      - "mod"
+policies:
+  - name: "foo"
+    file: "foo.hcl"
+  - name: "foo"
+    state: "absent"
+    tags:
+      - "remove"
+  - name: "foo"
+    file: "foo2.hcl"
+    tags:
+      - "mod"

--- a/tests/integration/fixtures/diff/vault/foo.hcl
+++ b/tests/integration/fixtures/diff/vault/foo.hcl
@@ -1,0 +1,4 @@
+#test1
+path "foo/*" {
+  capabilities = ["read", "list"]
+}

--- a/tests/integration/fixtures/diff/vault/foo2.hcl
+++ b/tests/integration/fixtures/diff/vault/foo2.hcl
@@ -1,0 +1,4 @@
+#test2
+path "foo/*" {
+  capabilities = ["read", "list"]
+}

--- a/tests/integration/fixtures/generic/Secretfile
+++ b/tests/integration/fixtures/generic/Secretfile
@@ -1,4 +1,5 @@
 # -*-YAML-*-
+
 secrets:
 - files:
   - source: 'secret.txt'

--- a/tests/integration/fixtures/mount/Secretfile
+++ b/tests/integration/fixtures/mount/Secretfile
@@ -1,0 +1,27 @@
+# -*-YAML-*-
+---
+mounts:
+  - path: "also_secret"
+    description: "some kinda"
+  - path: "also_secret"
+    state: "absent"
+    tags:
+    - "remove"
+  - path: "also_secret"
+    tags:
+    - "mod"
+    tune:
+      max_lease_ttl: "1d"
+      default_lease_ttl: "3600s"
+
+secrets:
+  - files:
+      - source: 'secret.txt'
+        name: 'secret'
+    mount: 'also_secret'
+    path: 'bar'
+    tags: ['file_warn']
+  - var_file: 'secret.yml'
+    mount: 'also_secret'
+    path: 'bar'
+    tags: ['var_file_warn']

--- a/tests/integration/helper.bash
+++ b/tests/integration/helper.bash
@@ -163,7 +163,7 @@ function aomi_run() {
 }
 
 function aomi_seed() {
-    aomi_run seed "$@"
+    aomi_run seed "$@" --verbose
 }
 
 function check_mount() {

--- a/tests/integration/mount.bats
+++ b/tests/integration/mount.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# -*- mode: Shell-script;bash -*-
+# tests for mount/backend crud
+load helper
+
+setup() {
+    start_vault
+    use_fixture mount
+}
+
+teardown() {
+    stop_vault
+    rm -rf "$FIXTURE_DIR"
+}
+
+@test "crud a kv/generic mount" {
+    aomi_run diff --verbose --monochrome
+    scan_lines "\+ generic also_secret" "${lines[@]}"
+    aomi_seed
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "\- generic also_secret" "${lines[@]}"
+    aomi_run diff --monochrome --tags mod
+    scan_lines "\~ generic also_secret" "${lines[@]}"
+    scan_lines "\-\- default_lease_ttl: 2764800" "${lines[@]}"
+    scan_lines "\-\- max_lease_ttl: 2764800" "${lines[@]}"  
+    scan_lines "\+\+ default_lease_ttl: 3600" "${lines[@]}"
+    scan_lines "\+\+ max_lease_ttl: 86400" "${lines[@]}"
+    aomi_seed --tags mod
+    aomi_seed --tags remove
+}
+
+@test "warning on assumed generic mount" {
+    aomi_run seed --tags file_warn
+    scan_lines "^Ad-Hoc mount with Generic File also_secret/bar.+$" "${lines[@]}"
+    aomi_run seed --tags var_file_warn
+    scan_lines "^Ad-Hoc mount with Generic VarFile also_secret/bar.+" "${lines[@]}"    
+}


### PR DESCRIPTION
This brings #101, #86, and #110 into play. Ad-Hoc backend creation is now no longer a thing, however it will still work for Generic secrets (albeit with a deprecation warning). It will no longer work for UserPass. Note that you can only adjust the mount tune parameters on Vault versions 0.7.0 and above.

This PR also introduces a slightly tighter linking between certain flavours of `Resource` and appropriate `VaultBackend` implementations. Not super happy about it, and I think that it should probably get cleaned (maybe making backends full-on `Resource` implementations).

Before this gets merged I want to do the following

- [x] add more tests on diff actions
- [x] tests around mount tuning crud for all backends
- [x] ensure both old/new mount patterns are tested
- [x] update docs