### PR TITLE
do not interrogate vault server version until connect step

### DIFF
--- a/aomi/model/generic.py
+++ b/aomi/model/generic.py
@@ -45,6 +45,7 @@ class VarFile(Generic):
 
     def obj(self):
         filename = hard_path(self.filename, self.opt.secrets)
+        secret_file(filename)
         template_obj = load_vars(self.opt)
         return load_var_file(filename, template_obj)
 

--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -159,6 +159,10 @@ class Client(hvac.Client):
         vsn_string = ""
         if self.version:
             vsn_string = ", v%s" % self.version
+        else:
+            LOG.warning("Unable to deterine Vault version. Not all "
+                        "functionality is supported")
+
         LOG.info("Connected to %s as %s%s",
                  self._url,
                  display_name,

--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -104,6 +104,7 @@ class Client(hvac.Client):
     def __init__(self, _url=None, token=None, _cert=None, _verify=True,
                  _timeout=30, _proxies=None, _allow_redirects=True,
                  _session=None):
+        self.version = None
         self.vault_addr = os.environ.get('VAULT_ADDR')
         if not self.vault_addr:
             raise aomi.exceptions.AomiError('VAULT_ADDR is undefined or empty')
@@ -126,14 +127,13 @@ class Client(hvac.Client):
         super(Client, self).__init__(url=self.vault_addr,
                                      verify=ssl_verify,
                                      session=session)
-        self.version = self.server_version(session)
 
-    def server_version(self, session):
+    def server_version(self):
         """Attempts to determine the version of Vault that a
         server is running. Some actions will change on older
         Vault deployments."""
         health_url = "%s/v1/sys/health" % self.vault_addr
-        resp = session.request('get', health_url)
+        resp = self.session.request('get', health_url)
         if resp.status_code == 200 or resp.status_code == 429:
             blob = resp.json()
             if 'version' in blob:
@@ -146,6 +146,7 @@ class Client(hvac.Client):
     def connect(self, opt):
         """This sets up the tokens we expect to see in a way
         that hvac also expects."""
+        self.version = self.server_version()
         if not self._kwargs['verify']:
             LOG.warning('Skipping SSL Validation!')
 

--- a/tests/integration/ux.bats
+++ b/tests/integration/ux.bats
@@ -19,6 +19,12 @@ teardown() {
     VAULT_TOKEN="" VAULT_TOKEN_FILE="${BATS_TMPDIR}/token" aomi_seed
 }
 
+@test "do not use insecure files" {
+    chmod -R og+rw ".secrets"
+    aomi_run_rc 1 seed
+    scan_lines "^.+loose permissions$" "${lines[@]}"
+}
+
 @test "builtin template help" {
     aomi_run template --builtin-list
     scan_lines "shenv" "${lines[@]}"


### PR DESCRIPTION
Address issues when running `output` or `freeze` / etc in an env that is not setup for Vault.