### PR TITLE
backwards compatible secret renewal

### DIFF
--- a/aomi/render.py
+++ b/aomi/render.py
@@ -10,45 +10,9 @@ from cryptorito import portable_b64decode, is_base64
 from aomi.helpers import merge_dicts, cli_hash, \
     path_pieces, abspath
 from aomi.template import render, load_vars
+from aomi.vault import renew_secret, is_aws
 import aomi.exceptions
 LOG = logging.getLogger(__name__)
-
-
-def grok_seconds(lease):
-    """Ensures that we are returning just seconds"""
-    if lease.endswith('s'):
-        return int(lease[0:-1])
-    elif lease.endswith('m'):
-        return int(lease[0:-1]) * 60
-    elif lease.endswith('h'):
-        return int(lease[0:-1]) * 3600
-
-    return None
-
-
-def is_aws(data):
-    """Takes a decent guess as to whether or not we are dealing with
-    an AWS secret blob"""
-    return 'access_key' in data and 'secret_key' in data
-
-
-def renew_secret(client, creds, opt):
-    """Renews a secret. This will occur unless the user has
-    specified on the command line that it is not neccesary"""
-    if opt.reuse_token:
-        return
-
-    seconds = grok_seconds(opt.lease)
-    if not seconds:
-        raise aomi.exceptions.AomiCommand("invalid lease %s" % opt.lease)
-
-    renew = client.renew_secret(creds['lease_id'], seconds)
-    # sometimes it takes a bit for vault to respond
-    # if we are within 5s then we are fine
-    if seconds - renew['lease_duration'] >= 5:
-        client.revoke_self_token()
-        e_msg = 'Unable to renew with desired lease'
-        raise aomi.exceptions.VaultConstraint(e_msg)
 
 
 def secret_key_name(path, key, opt):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,29 +1,8 @@
 import sys
 import unittest
-from aomi.render import secret_key_name, cli_hash, grok_template_file, is_aws, grok_seconds
+from aomi.render import secret_key_name, cli_hash, grok_template_file
 from aomi.cli import parser_factory
 
-
-class HelperTest(unittest.TestCase):
-    def test_seconds_to_seconds(self):
-        assert grok_seconds('1s') == 1
-        assert grok_seconds('60s') == 60
-        assert grok_seconds('120s') == 120
-
-    def test_minutes_to_seconds(self):
-        assert grok_seconds('1m') == 60
-        assert grok_seconds('60m') == 3600
-
-    def test_hours_to_seconds(self):
-        assert grok_seconds('1h') == 3600
-        assert grok_seconds('24h') == 86400
-
-    def test_is_aws(self):
-        assert is_aws({'access_key': True, 'secret_key': True})
-        assert is_aws({'access_key': True, 'secret_key': True, 'security_token': True})
-
-    def test_is_not_aws(self):
-        assert not is_aws({'aaa': True})
 
 class TemplateTest(unittest.TestCase):
     def test_builtin(self):

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,24 @@
+import unittest
+from aomi.vault import grok_seconds, is_aws
+
+class HelperTest(unittest.TestCase):
+    def test_seconds_to_seconds(self):
+        assert grok_seconds('1s') == 1
+        assert grok_seconds('60s') == 60
+        assert grok_seconds('120s') == 120
+
+    def test_minutes_to_seconds(self):
+        assert grok_seconds('1m') == 60
+        assert grok_seconds('60m') == 3600
+
+    def test_hours_to_seconds(self):
+        assert grok_seconds('1h') == 3600
+        assert grok_seconds('24h') == 86400
+
+    def test_is_aws(self):
+        assert is_aws({'access_key': True, 'secret_key': True})
+        assert is_aws({'access_key': True, 'secret_key': True, 'security_token': True})
+
+    def test_is_not_aws(self):
+        assert not is_aws({'aaa': True})
+


### PR DESCRIPTION
Let's see if this confuses the test coverage tracker...

Problem stemmed from merging [this](https://github.com/ianunruh/hvac/pull/125) `hvac` PR which uses the most recent API for HCV. I've opened [this](https://github.com/ianunruh/hvac/issues/148) issue to see if the `hvac` community cares about backwards compatibility (with HCV, not internally) but in the mean time this covers the `aomi` usage.