### PR TITLE
handle another^H^H^H^H^H^H^Hmore backwards compatibility regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ aomi/version
 docs/.sass-cache/
 docs/_site
 .coverage
+errata/pipeline/.env

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: version testenv
 	$(CIENV)coverage erase
 	$(CIENV)pycodestyle aomi
 	$(CIENV)pylint --rcfile=/dev/null aomi
-	COVERAGE_FILE="$(pwd)/.coverage" $(CIENV)nose2 -v -C --coverage aomi
+	COVERAGE_FILE="$(shell pwd)/.coverage" $(CIENV)nose2 -v -C --coverage aomi
 	$(CIENV)bandit -r aomi
 	$(CIENV)vulture aomi
 	./scripts/integration

--- a/aomi/model/backend.py
+++ b/aomi/model/backend.py
@@ -35,13 +35,13 @@ class VaultBackend(object):
 
         return "%s %s" % (self.backend, self.path)
 
-    def __init__(self, resource, opt):
+    def __init__(self, resource, opt, managed=True):
         self.path = sanitize_mount(resource.mount)
         self.backend = resource.backend
         self.existing = dict()
         self.present = resource.present
-        self.tune = dict()
-        self.description = None
+        self.config = dict()
+        self.managed = managed
         if hasattr(resource, 'tune') and isinstance(resource.tune, dict):
             for tunable in MOUNT_TUNABLES:
                 tunable_key = tunable[0]
@@ -52,17 +52,12 @@ class VaultBackend(object):
                             (tunable_key, self.path, tunable_type)
                     raise aomi_excep.AomiData(e_msg)
 
-                map_val(self.tune, resource.tune, tunable_key)
+                map_val(self.config, resource.tune, tunable_key)
 
             if 'description' in resource.tune:
-                self.description = resource.tune['description']
+                self.config['description'] = resource.tune['description']
 
         self.opt = opt
-
-    def update_tune(self):
-        """Determines if we need to update our tune metadata or not.
-        We only do this if we are specifying anything, and it has been
-        explicitly set in the data model"""
 
     def diff(self):
         """Determines if changes are needed for the Vault backend"""
@@ -75,16 +70,15 @@ class VaultBackend(object):
 
         is_diff = NOOP
         if self.present and self.existing:
-            a_obj = self.tune.copy()
-            a_obj['description'] = self.description
-            if self.tune and diff_dict(a_obj, self.existing, True):
+            a_obj = self.config.copy()
+            if self.config and diff_dict(a_obj, self.existing, True):
                 is_diff = CHANGED
+
+            if self.description != self.existing.get('description'):
+                is_diff = CONFLICT
 
         elif self.present and not self.existing:
             is_diff = ADD
-
-        if self.description != self.existing.get('description'):
-            is_diff = CONFLICT
 
         return is_diff
 
@@ -99,8 +93,6 @@ class VaultBackend(object):
             else:
                 LOG.info("%s backend already mounted on %s",
                          self.backend, self.path)
-
-            self.update_tune()
         else:
             if self.existing:
                 LOG.info("Unmounting %s backend on %s",
@@ -115,7 +107,7 @@ class VaultBackend(object):
 
     def sync_tunables(self, vault_client):
         """Synchtonizes any tunables we have set"""
-        if not self.tune:
+        if not self.config:
             return
 
         a_prefix = self.tune_prefix
@@ -123,7 +115,11 @@ class VaultBackend(object):
             a_prefix = "%s/" % self.tune_prefix
 
         v_path = "sys/mounts/%s%s/tune" % (a_prefix, self.path)
-        t_resp = vault_client.write(v_path, **self.tune)
+        a_obj = self.config.copy()
+        if 'description' in a_obj:
+            del a_obj['description']
+
+        t_resp = vault_client.write(v_path, **a_obj)
         if t_resp and 'errors' in t_resp and t_resp['errors']:
             e_msg = "Unable to update tuning info for %s" % self
             raise aomi_excep.VaultData(e_msg)
@@ -135,12 +131,15 @@ class VaultBackend(object):
            self.tune_prefix is None:
             return
 
-        if vault_client.version is None:
-            backend_details = get_backend(self.backend, self.path, backends)
-            self.existing = backend_details['config']
-            if backend_details['description']:
-                self.existing['description'] = backend_details['description']
+        backend_details = get_backend(self.backend, self.path, backends)
+        self.existing = backend_details['config']
+        if backend_details['description']:
+            self.existing['description'] = backend_details['description']
 
+        if vault_client.version is None:
+            return
+
+        if not self.managed:
             return
 
         a_prefix = self.tune_prefix
@@ -155,7 +154,6 @@ class VaultBackend(object):
 
         e_obj = t_resp['data']
         e_obj['description'] = None
-
         n_path = normalize_vault_path(self.path)
         if n_path in backends:
             a_mount = backends[n_path]
@@ -170,21 +168,25 @@ class VaultBackend(object):
 
     def actually_mount(self, client):
         """Actually mount something in Vault"""
+        a_obj = self.config.copy()
+        if 'description' in a_obj:
+            del a_obj['description']
+
         try:
             m_fun = getattr(client, self.mount_fun)
-            if self.description and self.tune:
+            if self.description and a_obj:
                 m_fun(self.backend,
                       mount_point=self.path,
                       description=self.description,
-                      config=self.tune)
+                      config=a_obj)
             elif self.description:
                 m_fun(self.backend,
                       mount_point=self.path,
                       description=self.description)
-            elif self.tune:
+            elif a_obj:
                 m_fun(self.backend,
                       mount_point=self.path,
-                      config=self.tune)
+                      config=a_obj)
             else:
                 m_fun(self.backend,
                       mount_point=self.path)
@@ -214,14 +216,14 @@ class AuthBackend(VaultBackend):
 
     def actually_mount(self, client):
         m_fun = getattr(client, self.mount_fun)
-        if self.description and self.tune:
+        if self.description and self.config and 'description' in self.config:
             m_fun(self.backend,
                   mount_point=self.path,
-                  description=self.description)
+                  description=self.config['description'])
         elif self.description:
             m_fun(self.backend,
                   mount_point=self.path,
-                  description=self.description)
+                  description=self.config['description'])
         else:
             m_fun(self.backend,
                   mount_point=self.path)
@@ -234,8 +236,8 @@ class LogBackend(VaultBackend):
     unmount_fun = 'disable_audit_backend'
     tune_prefix = None
 
-    def __init__(self, resource, opt):
-        super(LogBackend, self).__init__(resource, opt)
+    def __init__(self, resource, opt, managed=True):
+        super(LogBackend, self).__init__(resource, opt, managed)
         self.obj = resource.obj()
 
     def actually_mount(self, client):

--- a/aomi/model/ssh.py
+++ b/aomi/model/ssh.py
@@ -18,7 +18,7 @@ class SSHRole(Secret):
             'key_type': obj['key_type']
         }
         if 'cidr_list' in obj:
-            self._obj['cidr_list'] = obj['cidr_list']
+            self._obj['cidr_list'] = ','.join(obj['cidr_list'])
 
         if 'default_user' in obj:
             self._obj['default_user'] = obj['default_user']

--- a/aomi/seed_action.py
+++ b/aomi/seed_action.py
@@ -154,7 +154,7 @@ def maybe_details(resource, opt):
         obj = resource.obj()
         existing = resource.existing
     elif isinstance(resource, VaultBackend):
-        obj = resource.tune
+        obj = resource.config
         existing = resource.existing
 
     if not obj:

--- a/aomi/vault.py
+++ b/aomi/vault.py
@@ -111,15 +111,20 @@ def token_meta(opt):
     return meta
 
 
-def is_mounted(backend, path, backends):
-    """Determine whether a backend of a certain type is mounted"""
+def get_backend(backend, path, backends):
+    """Returns mountpoint details for a backend"""
+    m_norm = normalize_vault_path(path)
     for mount_name, values in backends.items():
         b_norm = normalize_vault_path(mount_name)
-        m_norm = normalize_vault_path(path)
         if (m_norm == b_norm) and values['type'] == backend:
-            return True
+            return values
 
-    return False
+    return None
+
+
+def is_mounted(backend, path, backends):
+    """Determine whether a backend of a certain type is mounted"""
+    return get_backend(backend, path, backends) is not None
 
 
 def wrap_hvac(msg):

--- a/tests/integration/a_smoke.bats
+++ b/tests/integration/a_smoke.bats
@@ -14,9 +14,14 @@ teardown() {
     rm -rf "$FIXTURE_DIR"
 }
 
+@test "can seed as root and not as root" {
+    aomi_seed
+    test_user foo
+    aomi_seed --tags bar
+}
+
 @test "can seed and extract a file" {
     aomi_seed --tags bar
-    [ "$status" -eq 0 ]    
     aomi_run extract_file \
         foo/bar/baz/secret \
         "${BATS_TMPDIR}/secret.txt" \

--- a/tests/integration/diff.bats
+++ b/tests/integration/diff.bats
@@ -19,14 +19,15 @@ teardown() {
     aomi_seed
     aomi_run diff --verbose --monochrome    
     scan_lines "!\+ Vault Policy foo" "${lines[@]}"
-    aomi_run diff --verbose --monochrome --tags remove
-    scan_lines "\- Vault Policy foo" "${lines[@]}"
-    aomi_run diff --verbose --monochrome
-    scan_lines "!\- Vault Policy foo" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags mod
     scan_lines "\~ Vault Policy foo" "${lines[@]}"
     scan_lines "\-\- #test1" "${lines[@]}"
-    scan_lines "\+\+ #test2" "${lines[@]}"    
+    scan_lines "\+\+ #test2" "${lines[@]}"
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "\- Vault Policy foo" "${lines[@]}"
+    aomi_seed --tags remove    
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "!\- Vault Policy foo" "${lines[@]}"
 }
 
 @test "crud some secret diffs" {
@@ -39,10 +40,6 @@ teardown() {
     scan_lines "!\+ Generic File secret/foo" "${lines[@]}"
     scan_lines "!\+ Generic VarFile secret/bar" "${lines[@]}"
     scan_lines "!\+ generic also_secret" "${lines[@]}"    
-    aomi_run diff --verbose --monochrome --tags remove
-    scan_lines "\- Generic File secret/foo" "${lines[@]}"
-    scan_lines "\- Generic VarFile secret/bar" "${lines[@]}"    
-    scan_lines "\- generic also_secret" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags mod
     scan_lines "\~ Generic File secret/foo" "${lines[@]}"
     scan_lines "\-\- txt2: ${FILE_SECRET2}" "${lines[@]}"
@@ -51,4 +48,13 @@ teardown() {
     scan_lines "\-\- secret2: ${YAML_SECRET1_2}" "${lines[@]}"
     scan_lines "\+\+ secret: ${YAML_SECRET2}" "${lines[@]}"
     scan_lines "\+\+ secret2: ${YAML_SECRET2_2}" "${lines[@]}"
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "\- Generic File secret/foo" "${lines[@]}"
+    scan_lines "\- Generic VarFile secret/bar" "${lines[@]}"    
+    scan_lines "\- generic also_secret" "${lines[@]}"
+    aomi_seed --tags remove
+    aomi_run diff --verbose --monochrome --tags remove
+    scan_lines "!\- Generic File secret/foo" "${lines[@]}"
+    scan_lines "!\- Generic VarFile secret/bar" "${lines[@]}"    
+    scan_lines "!\- generic also_secret" "${lines[@]}"
 }

--- a/tests/integration/diff.bats
+++ b/tests/integration/diff.bats
@@ -17,8 +17,12 @@ teardown() {
     aomi_run diff --verbose --monochrome
     scan_lines "\+ Vault Policy foo" "${lines[@]}"
     aomi_seed
+    aomi_run diff --verbose --monochrome    
+    scan_lines "!\+ Vault Policy foo" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags remove
     scan_lines "\- Vault Policy foo" "${lines[@]}"
+    aomi_run diff --verbose --monochrome
+    scan_lines "!\- Vault Policy foo" "${lines[@]}"
     aomi_run diff --verbose --monochrome --tags mod
     scan_lines "\~ Vault Policy foo" "${lines[@]}"
     scan_lines "\-\- #test1" "${lines[@]}"
@@ -31,6 +35,10 @@ teardown() {
     scan_lines "\+ Generic VarFile secret/bar" "${lines[@]}"
     scan_lines "\+ generic also_secret" "${lines[@]}"
     aomi_seed
+    aomi_run diff --verbose --monochrome
+    scan_lines "!\+ Generic File secret/foo" "${lines[@]}"
+    scan_lines "!\+ Generic VarFile secret/bar" "${lines[@]}"
+    scan_lines "!\+ generic also_secret" "${lines[@]}"    
     aomi_run diff --verbose --monochrome --tags remove
     scan_lines "\- Generic File secret/foo" "${lines[@]}"
     scan_lines "\- Generic VarFile secret/bar" "${lines[@]}"    

--- a/tests/integration/fixtures/generic/vault/sample.hcl
+++ b/tests/integration/fixtures/generic/vault/sample.hcl
@@ -1,6 +1,12 @@
 path "foo/*" {
-  capabilities = ["read"]
+  capabilities = ["read", "update", "create", "delete"]
 }
 path "auth/token/lookup-self" {
   capabilities = ["read"]
+}
+path "auth/token/create" {
+  capabilities = ["create", "update"]
+}
+path "sys/mounts" {
+  capabilities = [ "read" ]
 }

--- a/tests/integration/fixtures/mount/Secretfile
+++ b/tests/integration/fixtures/mount/Secretfile
@@ -3,16 +3,17 @@
 mounts:
   - path: "also_secret"
     description: "some kinda"
-  - path: "also_secret"
-    state: "absent"
-    tags:
-    - "remove"
-  - path: "also_secret"
+  - path: "also_secret" 
+    description: "some kinda"
     tags:
     - "mod"
     tune:
       max_lease_ttl: "1d"
       default_lease_ttl: "3600s"
+  - path: "also_secret"
+    state: "absent"
+    tags:
+    - "remove"
 
 secrets:
   - files:

--- a/tests/integration/fixtures/ssh/Secretfile
+++ b/tests/integration/fixtures/ssh/Secretfile
@@ -9,4 +9,7 @@ secrets:
   name: "bar"
   key_type: "otp"
   default_user: "also_nobody"
+  cidr_list:
+    - "127.0.0.1/32"
+    - "127.0.0.2/32"
   state: "{{a_state|default("present")}}"

--- a/tests/integration/helper.bash
+++ b/tests/integration/helper.bash
@@ -180,14 +180,19 @@ function check_mount() {
 
 scan_lines() {
     local STRING="$1"
+    local NEG
+    if [ "${STRING:0:1}" == "!" ] ; then
+        NEG="yes"
+        STRING="${STRING:1}"
+    fi
     shift
     while [ ! -z "$1" ] ; do
         if grep -qE "$STRING" <<< "$1" ; then
-            return 0
+            [ -z "$NEG" ] && return 0 || return 1
         fi
         shift
     done
-    return 1
+    [ -z "$NEG" ] && return 1 || return 0
 }
 
 function aws_creds() {

--- a/tests/integration/helper.bash
+++ b/tests/integration/helper.bash
@@ -292,3 +292,17 @@ function check_aws {
         fi
     done
 }
+
+function test_user() {
+    [ "$#" == "1" ]
+    POLICY="$1"
+    unset VAULT_TOKEN
+    local a_token=$(vault \
+                        token-create \
+                        -policy="$POLICY" \
+                        -display-name=testuser \
+                        -format=json 2> /dev/null | jq -Mr ".auth.client_token")
+    if [ ! -z "$a_token" ] ; then
+        export VAULT_TOKEN="$a_token"
+    fi
+}


### PR DESCRIPTION
This regression was in the ability to detect whether or not backends have changed or not. There is a likely future optimization in the `Backend.fetch` function but outside the scope of this PR.

Also added to the `diff` integration test to make sure we test the `NOOP` case.

And I have no idea how line 25 of the `Makefile` ever worked before but it works now (I'm assuming something on the `coverage` tool changed).

cc @fortinmath

- [x] confirm if this regression is in ldap/userpass
- [x] better test coverage on diff